### PR TITLE
[fix] #19 URLがちゃんとバインドされるように修正

### DIFF
--- a/src/components/BookInfo.vue
+++ b/src/components/BookInfo.vue
@@ -12,7 +12,7 @@
       <div class="posts-info">
         <h4>関連URL</h4>
         <ul>
-          <li v-for="list in posts" v-bind:key="list.id"><a href="list.url">{{ list }}</a></li>
+          <li v-for="list in posts" v-bind:key="list.id"><a v-bind:href="list">{{ list }}</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
v-bindでhref属性にURLを割り当てる必要があったけど、このやり方が間違っていた。

v-bind:href="実際に割り当てたいデータ"とするべきだったところができていなかった

close #28 