### PR TITLE
[fix] #34  配列の最後になるとundefinedが発生してしまっていた不具合を修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -64,10 +64,13 @@ export default {
   },
   methods: {
     addCount() {
-      if (this.bookId !== bookData.length ) {
+      if (this.bookId < bookData.length -1) {
         return this.bookId++;
-      } else {
-        return;
+      } else if (this.bookId >= bookData.length - 1) {
+          this.bookId = bookData.length - 1;
+          return this.bookId;
+        } else {
+          return;
       }
     },
     removeCount() {


### PR DESCRIPTION
配列の長さで判定すると、bookIdが配列 + 1された状態になってしまい、JSONのデータ数を超えてしまっていた。結果としてデータが存在せずundefinedになっていた。

close #34 